### PR TITLE
Fix test portability: replace hardcoded path, handle missing pytest-a…

### DIFF
--- a/src/pgmonkey/tests/conftest.py
+++ b/src/pgmonkey/tests/conftest.py
@@ -4,6 +4,17 @@ import tempfile
 import os
 
 
+def pytest_collection_modifyitems(config, items):
+    """Skip async tests gracefully when pytest-asyncio is not installed."""
+    try:
+        import pytest_asyncio  # noqa: F401
+    except ImportError:
+        skip_async = pytest.mark.skip(reason="pytest-asyncio is not installed")
+        for item in items:
+            if "asyncio" in item.keywords:
+                item.add_marker(skip_async)
+
+
 @pytest.fixture
 def sample_config():
     """Returns a full pgmonkey configuration dictionary for testing."""

--- a/src/pgmonkey/tests/integration/test_pgconnection_manager_integration.py
+++ b/src/pgmonkey/tests/integration/test_pgconnection_manager_integration.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import psycopg
 import psycopg_pool
 import yaml
@@ -6,8 +7,15 @@ import sys
 import pytest
 from pgmonkey import PGConnectionManager
 
-# Single config file serves all connection types
-CONFIG_FILE = "/home/ubuntu/myconnectionconfigs/pg_connection.yaml"
+pytest.importorskip("pytest_asyncio")
+
+# Config file path from environment variable — set PGMONKEY_TEST_CONFIG to your YAML config path.
+CONFIG_FILE = os.environ.get("PGMONKEY_TEST_CONFIG")
+if CONFIG_FILE is None:
+    pytest.skip(
+        "PGMONKEY_TEST_CONFIG environment variable not set — skipping integration tests",
+        allow_module_level=True,
+    )
 
 
 def print_version_info():

--- a/src/pgmonkey/tests/unit/test_async_connection.py
+++ b/src/pgmonkey/tests/unit/test_async_connection.py
@@ -1,5 +1,8 @@
 import pytest
 from unittest.mock import patch, AsyncMock
+
+pytest.importorskip("pytest_asyncio")
+
 from pgmonkey.connections.postgres.async_connection import PGAsyncConnection
 
 

--- a/src/pgmonkey/tests/unit/test_async_pool_connection.py
+++ b/src/pgmonkey/tests/unit/test_async_pool_connection.py
@@ -1,5 +1,8 @@
 import pytest
 from unittest.mock import patch, AsyncMock
+
+pytest.importorskip("pytest_asyncio")
+
 from pgmonkey.connections.postgres.async_pool_connection import PGAsyncPoolConnection
 
 


### PR DESCRIPTION
…syncio

- Integration test now reads config path from PGMONKEY_TEST_CONFIG env var instead of hardcoded /home/ubuntu/... path, skips if unset
- Async test files skip gracefully via pytest.importorskip when pytest-asyncio is not installed
- conftest.py hook auto-skips @pytest.mark.asyncio tests in mixed files when pytest-asyncio is unavailable

https://claude.ai/code/session_012h6nkYxP21VoDQk7PWXCzd