### PR TITLE
Fix twine check error: change license field from file to text format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A tool to assist with postgresql database connections"
 readme = "README.md"
-license = { file="LICENSE" }
+license = {text = "MIT"}
 requires-python = ">=3.10,<3.14"
 classifiers = [
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The table form `license = { file="LICENSE" }` causes setuptools to emit a `License-File` metadata field that older twine/packaging versions do not recognize, resulting in an InvalidDistribution error.

https://claude.ai/code/session_012h6nkYxP21VoDQk7PWXCzd