### PR TITLE
Fix 8 best-practice issues: thread safety, GUC settings, SQL injectio…

### DIFF
--- a/src/pgmonkey/common/templates/postgres.yaml
+++ b/src/pgmonkey/common/templates/postgres.yaml
@@ -21,6 +21,16 @@ postgresql:
     keepalives_idle: '60'  # Seconds before sending a keepalive probe
     keepalives_interval: '15'  # Seconds between keepalive probes
     keepalives_count: '5'  # Max keepalive probes before closing the connection
+    # autocommit: false  # Enable autocommit mode (required for DDL like CREATE DATABASE, VACUUM, etc.)
+
+  # Session-level GUC settings for 'normal' and 'pool' connection types.
+  # For 'normal': applied via SET commands after connect.
+  # For 'pool': applied via psycopg_pool's configure callback on each checkout.
+  sync_settings:
+    # statement_timeout: '30000'  # Cancel statements exceeding this time (ms)
+    # lock_timeout: '10000'  # Timeout for acquiring locks (ms)
+    # idle_in_transaction_session_timeout: '5000'  # Timeout for idle in transaction (ms)
+    # work_mem: '256MB'  # Memory for sort operations and more
 
   # Settings for 'pool' connection type
   pool_settings:
@@ -30,8 +40,13 @@ postgresql:
     max_idle: 300  # Seconds a connection can remain idle before being closed
     max_lifetime: 3600  # Seconds a connection can be reused
     check_on_checkout: false  # Validate connections with SELECT 1 before handing to caller
+    # max_waiting: 0  # Max clients queued waiting for a connection (0 = unlimited)
+    # reconnect_timeout: 300  # Seconds to keep trying to reconnect failed connections (0 = forever)
+    # num_workers: 3  # Number of background workers maintaining pool connections
 
-  # Settings for 'async' connection type (applied via SET commands on connection)
+  # Session-level GUC settings for 'async' and 'async_pool' connection types.
+  # For 'async': applied via SET commands after connect.
+  # For 'async_pool': applied via psycopg_pool's configure callback on each checkout.
   async_settings:
     idle_in_transaction_session_timeout: '5000'  # Timeout for idle in transaction (ms)
     statement_timeout: '30000'  # Cancel statements exceeding this time (ms)
@@ -46,3 +61,6 @@ postgresql:
     max_idle: 300
     max_lifetime: 3600
     check_on_checkout: false  # Validate connections with SELECT 1 before handing to caller
+    # max_waiting: 0  # Max clients queued waiting for a connection (0 = unlimited)
+    # reconnect_timeout: 300  # Seconds to keep trying to reconnect failed connections (0 = forever)
+    # num_workers: 3  # Number of background workers maintaining pool connections

--- a/src/pgmonkey/connections/postgres/async_connection.py
+++ b/src/pgmonkey/connections/postgres/async_connection.py
@@ -11,12 +11,15 @@ class PGAsyncConnection(PostgresBaseConnection):
     def __init__(self, config, async_settings=None):
         self.config = config
         self.async_settings = async_settings or {}
+        self.autocommit = None
         self.connection: Optional[AsyncConnection] = None
 
     async def connect(self):
         """Establishes an asynchronous database connection."""
         if self.connection is None or self.connection.closed:
-            self.connection = await AsyncConnection.connect(**self.config)
+            self.connection = await AsyncConnection.connect(
+                autocommit=bool(self.autocommit), **self.config
+            )
             await self._apply_async_settings()
 
     async def _apply_async_settings(self):
@@ -58,7 +61,7 @@ class PGAsyncConnection(PostgresBaseConnection):
         """Creates a transaction context on the async connection."""
         if self.connection:
             async with self.connection.transaction():
-                yield
+                yield self
         else:
             raise Exception("No active connection available for transaction")
 
@@ -80,4 +83,3 @@ class PGAsyncConnection(PostgresBaseConnection):
             await self.rollback()
         else:
             await self.commit()
-        await self.disconnect()

--- a/src/pgmonkey/connections/postgres/async_pool_connection.py
+++ b/src/pgmonkey/connections/postgres/async_pool_connection.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+import contextvars
 from psycopg_pool import AsyncConnectionPool
 from psycopg import conninfo as psycopg_conninfo
 from .base_connection import PostgresBaseConnection
@@ -9,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 warnings.filterwarnings('ignore', category=RuntimeWarning, module='psycopg_pool')
 
+_async_pool_conn = contextvars.ContextVar('_async_pool_conn', default=None)
+_async_pool_conn_ctx = contextvars.ContextVar('_async_pool_conn_ctx', default=None)
+
 
 class PGAsyncPoolConnection(PostgresBaseConnection):
     def __init__(self, config, async_pool_settings=None, async_settings=None):
@@ -16,8 +20,6 @@ class PGAsyncPoolConnection(PostgresBaseConnection):
         self.async_pool_settings = async_pool_settings or {}
         self.async_settings = async_settings or {}
         self.pool = None
-        self._conn = None
-        self._pool_conn_ctx = None
 
     @staticmethod
     def construct_conninfo(config):
@@ -70,40 +72,48 @@ class PGAsyncPoolConnection(PostgresBaseConnection):
 
     async def commit(self):
         """Commits the current transaction on the acquired connection."""
-        if self._conn:
-            await self._conn.commit()
+        conn = _async_pool_conn.get()
+        if conn:
+            await conn.commit()
 
     async def rollback(self):
         """Rolls back the current transaction on the acquired connection."""
-        if self._conn:
-            await self._conn.rollback()
+        conn = _async_pool_conn.get()
+        if conn:
+            await conn.rollback()
 
     @asynccontextmanager
     async def transaction(self):
         """Creates a transaction context on a pooled connection."""
-        if self._conn:
+        conn = _async_pool_conn.get()
+        if conn:
             # Inside __aenter__/__aexit__ context - use the acquired connection
-            async with self._conn.transaction() as tx:
-                yield tx
+            async with conn.transaction():
+                yield self
         elif self.pool:
             # Standalone usage - acquire connection from pool
-            async with self.pool.connection() as conn:
-                async with conn.transaction() as tx:
-                    yield tx
+            async with self.pool.connection() as acquired:
+                token = _async_pool_conn.set(acquired)
+                try:
+                    async with acquired.transaction():
+                        yield self
+                finally:
+                    _async_pool_conn.reset(token)
         else:
             raise Exception("No active pool available for transaction")
 
     @asynccontextmanager
     async def cursor(self):
         """Provides an async cursor from a pooled connection."""
-        if self._conn:
+        conn = _async_pool_conn.get()
+        if conn:
             # Inside __aenter__/__aexit__ context - use the acquired connection
-            async with self._conn.cursor() as cur:
+            async with conn.cursor() as cur:
                 yield cur
         elif self.pool:
             # Standalone usage - acquire connection from pool
-            async with self.pool.connection() as conn:
-                async with conn.cursor() as cur:
+            async with self.pool.connection() as acquired:
+                async with acquired.cursor() as cur:
                     yield cur
         else:
             raise Exception("No active pool available for cursor")
@@ -111,20 +121,24 @@ class PGAsyncPoolConnection(PostgresBaseConnection):
     async def __aenter__(self):
         if not self.pool:
             await self.connect()
-        self._pool_conn_ctx = self.pool.connection()
-        self._conn = await self._pool_conn_ctx.__aenter__()
+        pool_conn_ctx = self.pool.connection()
+        conn = await pool_conn_ctx.__aenter__()
+        _async_pool_conn.set(conn)
+        _async_pool_conn_ctx.set(pool_conn_ctx)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         try:
+            conn = _async_pool_conn.get()
             if exc_type:
-                if self._conn:
-                    await self._conn.rollback()
+                if conn:
+                    await conn.rollback()
             else:
-                if self._conn:
-                    await self._conn.commit()
+                if conn:
+                    await conn.commit()
         finally:
-            if self._pool_conn_ctx:
-                await self._pool_conn_ctx.__aexit__(exc_type, exc_val, exc_tb)
-            self._conn = None
-            self._pool_conn_ctx = None
+            pool_conn_ctx = _async_pool_conn_ctx.get()
+            if pool_conn_ctx:
+                await pool_conn_ctx.__aexit__(exc_type, exc_val, exc_tb)
+            _async_pool_conn.set(None)
+            _async_pool_conn_ctx.set(None)

--- a/src/pgmonkey/connections/postgres/pool_connection.py
+++ b/src/pgmonkey/connections/postgres/pool_connection.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from contextlib import contextmanager, ExitStack
 from psycopg_pool import ConnectionPool
 from psycopg import OperationalError, conninfo as psycopg_conninfo
@@ -8,30 +9,50 @@ logger = logging.getLogger(__name__)
 
 
 class PGPoolConnection(PostgresBaseConnection):
-    def __init__(self, config, pool_settings=None):
+    def __init__(self, config, pool_settings=None, sync_settings=None):
         self.config = config
         self.pool_settings = pool_settings or {}
+        self.sync_settings = sync_settings or {}
         self.pool = None
-        self._conn = None
+        self._local = threading.local()
 
     @staticmethod
     def construct_conninfo(config):
         """Constructs a properly escaped connection info string from the config dictionary."""
         return psycopg_conninfo.make_conninfo(**config)
 
+    def _get_conn(self):
+        """Get the thread-local borrowed connection."""
+        return getattr(self._local, 'conn', None)
+
+    def _set_conn(self, value):
+        """Set the thread-local borrowed connection."""
+        self._local.conn = value
+
     def connect(self):
         """Initialize the connection pool."""
         if self.pool is None:
+            conninfo = self.construct_conninfo(self.config)
             kwargs = dict(self.pool_settings)
+
             check_on_checkout = kwargs.pop('check_on_checkout', False)
             if check_on_checkout:
                 def _check(conn):
                     conn.execute("SELECT 1")
                 kwargs['check'] = _check
-            self.pool = ConnectionPool(
-                conninfo=self.construct_conninfo(self.config),
-                **kwargs,
-            )
+
+            if self.sync_settings:
+                sync_settings = self.sync_settings
+
+                def _configure(conn):
+                    for setting, value in sync_settings.items():
+                        try:
+                            conn.execute(f"SET {setting} = %s", (str(value),))
+                        except Exception as e:
+                            logger.warning("Could not apply setting '%s': %s", setting, e)
+                kwargs['configure'] = _configure
+
+            self.pool = ConnectionPool(conninfo=conninfo, **kwargs)
 
     def test_connection(self):
         """Tests both a single connection and pooling behavior from the pool."""
@@ -70,38 +91,48 @@ class PGPoolConnection(PostgresBaseConnection):
             self.pool = None
 
     def commit(self):
-        if self._conn:
-            self._conn.commit()
+        conn = self._get_conn()
+        if conn:
+            conn.commit()
 
     def rollback(self):
-        if self._conn:
-            self._conn.rollback()
+        conn = self._get_conn()
+        if conn:
+            conn.rollback()
 
     def cursor(self):
-        if self._conn:
-            return self._conn.cursor()
+        conn = self._get_conn()
+        if conn:
+            return conn.cursor()
         else:
             raise Exception("No active connection available from the pool")
 
     @contextmanager
     def transaction(self):
         """Creates a transaction context for the pooled connection."""
-        with self.pool.connection() as conn:
-            self._conn = conn
-            try:
+        conn = self._get_conn()
+        if conn:
+            # Inside __enter__/__exit__ context - use the acquired connection
+            with conn.transaction():
                 yield self
-                self.commit()
-            except Exception:
-                self.rollback()
-                raise
-            finally:
-                self._conn = None
+        elif self.pool:
+            # Standalone usage - acquire connection from pool
+            with self.pool.connection() as acquired:
+                self._set_conn(acquired)
+                try:
+                    with acquired.transaction():
+                        yield self
+                finally:
+                    self._set_conn(None)
+        else:
+            raise Exception("No active pool available for transaction")
 
     def __enter__(self):
         """Acquire a connection from the pool."""
         if self.pool is None:
             self.connect()
-        self._conn = self.pool.connection().__enter__()
+        self._pool_conn_ctx = self.pool.connection()
+        self._set_conn(self._pool_conn_ctx.__enter__())
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -111,6 +142,8 @@ class PGPoolConnection(PostgresBaseConnection):
             else:
                 self.commit()
         finally:
-            if self._conn:
-                self._conn.__exit__(exc_type, exc_val, exc_tb)
-                self._conn = None
+            conn = self._get_conn()
+            if conn:
+                self._pool_conn_ctx.__exit__(exc_type, exc_val, exc_tb)
+                self._set_conn(None)
+            self._pool_conn_ctx = None

--- a/src/pgmonkey/tests/conftest.py
+++ b/src/pgmonkey/tests/conftest.py
@@ -38,6 +38,10 @@ def sample_config():
                 'keepalives_interval': '15',
                 'keepalives_count': '5',
             },
+            'sync_settings': {
+                'statement_timeout': '30000',
+                'lock_timeout': '10000',
+            },
             'pool_settings': {
                 'min_size': 2,
                 'max_size': 10,

--- a/src/pgmonkey/tests/unit/test_async_connection.py
+++ b/src/pgmonkey/tests/unit/test_async_connection.py
@@ -19,6 +19,10 @@ class TestPGAsyncConnectionInit:
         conn = PGAsyncConnection({'host': 'localhost'})
         assert conn.async_settings == {}
 
+    def test_default_autocommit_none(self):
+        conn = PGAsyncConnection({'host': 'localhost'})
+        assert conn.autocommit is None
+
 
 class TestPGAsyncConnectionConnect:
 
@@ -32,8 +36,21 @@ class TestPGAsyncConnectionConnect:
         conn = PGAsyncConnection({'host': 'localhost'}, {})
         await conn.connect()
 
-        mock_cls.connect.assert_called_once_with(host='localhost')
+        mock_cls.connect.assert_called_once_with(autocommit=False, host='localhost')
         assert conn.connection is mock_pg
+
+    @pytest.mark.asyncio
+    @patch('pgmonkey.connections.postgres.async_connection.AsyncConnection')
+    async def test_autocommit_passed_to_connect(self, mock_cls):
+        mock_pg = AsyncMock(closed=False)
+        mock_pg.execute = AsyncMock()
+        mock_cls.connect = AsyncMock(return_value=mock_pg)
+
+        conn = PGAsyncConnection({'host': 'localhost'}, {})
+        conn.autocommit = True
+        await conn.connect()
+
+        mock_cls.connect.assert_called_once_with(autocommit=True, host='localhost')
 
 
 class TestPGAsyncConnectionApplySettings:
@@ -98,3 +115,59 @@ class TestPGAsyncConnectionCommitRollback:
     async def test_rollback_noop_when_no_connection(self):
         conn = PGAsyncConnection({'host': 'localhost'})
         await conn.rollback()
+
+
+class TestPGAsyncConnectionContextManager:
+
+    @pytest.mark.asyncio
+    @patch('pgmonkey.connections.postgres.async_connection.AsyncConnection')
+    async def test_aexit_does_not_disconnect(self, mock_cls):
+        """__aexit__ should commit but not disconnect — connection stays alive for cache reuse."""
+        mock_pg = AsyncMock(closed=False)
+        mock_pg.execute = AsyncMock()
+        mock_pg.commit = AsyncMock()
+        mock_cls.connect = AsyncMock(return_value=mock_pg)
+
+        conn = PGAsyncConnection({'host': 'localhost'}, {})
+        async with conn:
+            pass
+
+        mock_pg.commit.assert_awaited_once()
+        mock_pg.close.assert_not_called()
+        assert conn.connection is mock_pg
+
+    @pytest.mark.asyncio
+    @patch('pgmonkey.connections.postgres.async_connection.AsyncConnection')
+    async def test_aexit_rollback_on_error(self, mock_cls):
+        mock_pg = AsyncMock(closed=False)
+        mock_pg.execute = AsyncMock()
+        mock_pg.rollback = AsyncMock()
+        mock_cls.connect = AsyncMock(return_value=mock_pg)
+
+        conn = PGAsyncConnection({'host': 'localhost'}, {})
+        with pytest.raises(ValueError):
+            async with conn:
+                raise ValueError("test")
+
+        mock_pg.rollback.assert_awaited_once()
+        mock_pg.commit.assert_not_awaited()
+
+
+class TestPGAsyncConnectionTransaction:
+
+    @pytest.mark.asyncio
+    @patch('pgmonkey.connections.postgres.async_connection.AsyncConnection')
+    async def test_transaction_yields_self(self, mock_cls):
+        """transaction() should yield self for consistency across all types."""
+        mock_pg = AsyncMock(closed=False)
+        mock_pg.execute = AsyncMock()
+        mock_pg.transaction = lambda: AsyncMock(
+            __aenter__=AsyncMock(),
+            __aexit__=AsyncMock(return_value=False),
+        )
+        mock_cls.connect = AsyncMock(return_value=mock_pg)
+
+        conn = PGAsyncConnection({'host': 'localhost'}, {})
+        await conn.connect()
+        async with conn.transaction() as tx:
+            assert tx is conn

--- a/src/pgmonkey/tests/unit/test_async_pool_connection.py
+++ b/src/pgmonkey/tests/unit/test_async_pool_connection.py
@@ -1,9 +1,11 @@
 import pytest
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 pytest.importorskip("pytest_asyncio")
 
-from pgmonkey.connections.postgres.async_pool_connection import PGAsyncPoolConnection
+from pgmonkey.connections.postgres.async_pool_connection import (
+    PGAsyncPoolConnection, _async_pool_conn, _async_pool_conn_ctx,
+)
 
 
 class TestPGAsyncPoolConnectionInit:
@@ -27,6 +29,12 @@ class TestPGAsyncPoolConnectionInit:
         conn = PGAsyncPoolConnection({'host': 'localhost'})
         assert conn.async_pool_settings == {}
         assert conn.async_settings == {}
+
+    def test_no_instance_conn_attribute(self):
+        """_conn is now stored in ContextVar, not on the instance."""
+        conn = PGAsyncPoolConnection({'host': 'localhost'})
+        assert not hasattr(conn, '_conn')
+        assert not hasattr(conn, '_pool_conn_ctx')
 
 
 class TestPGAsyncPoolConnectionConnect:
@@ -67,12 +75,13 @@ class TestPGAsyncPoolConnectionDisconnect:
 class TestPGAsyncPoolConnectionCommitRollback:
 
     @pytest.mark.asyncio
-    async def test_commit_is_noop(self):
+    async def test_commit_is_noop_when_no_contextvar(self):
+        """commit() is a no-op when no connection is stored in ContextVar."""
         conn = PGAsyncPoolConnection({'host': 'localhost'})
         await conn.commit()
 
     @pytest.mark.asyncio
-    async def test_rollback_is_noop(self):
+    async def test_rollback_is_noop_when_no_contextvar(self):
         conn = PGAsyncPoolConnection({'host': 'localhost'})
         await conn.rollback()
 
@@ -85,3 +94,161 @@ class TestPGAsyncPoolConnectionConninfo:
         result = PGAsyncPoolConnection.construct_conninfo({'host': 'localhost'})
         mock_conninfo.make_conninfo.assert_called_once_with(host='localhost')
         assert result == 'host=localhost'
+
+
+class TestPGAsyncPoolConnectionContextVar:
+    """Verify that _conn is stored in ContextVar, not on the instance."""
+
+    @pytest.mark.asyncio
+    async def test_contextvar_used_for_conn(self):
+        """__aenter__ stores connection in ContextVar, __aexit__ clears it."""
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.rollback = AsyncMock()
+
+        mock_pool_ctx = AsyncMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(return_value=mock_pool_ctx)
+
+        # Before entering: no connection in ContextVar
+        assert _async_pool_conn.get() is None
+
+        async with pool_conn:
+            # Inside context: connection is in ContextVar
+            assert _async_pool_conn.get() is mock_inner_conn
+
+        # After exiting: ContextVar cleared
+        assert _async_pool_conn.get() is None
+
+    @pytest.mark.asyncio
+    async def test_context_manager_does_not_close_pool(self):
+        """async with pool: should return connection to pool, not close it."""
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.rollback = AsyncMock()
+
+        mock_pool_ctx = AsyncMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(return_value=mock_pool_ctx)
+
+        async with pool_conn:
+            pass
+
+        # Pool must NOT be closed
+        assert pool_conn.pool is not None
+        pool_conn.pool.close.assert_not_called()
+        # Connection returned via pool context manager exit
+        mock_pool_ctx.__aexit__.assert_awaited_once()
+        # Commit on clean exit
+        mock_inner_conn.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_rollback_on_exception(self):
+        """async with pool: should rollback on exception, still return connection."""
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.rollback = AsyncMock()
+
+        mock_pool_ctx = AsyncMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(return_value=mock_pool_ctx)
+
+        with pytest.raises(ValueError):
+            async with pool_conn:
+                raise ValueError("test error")
+
+        # Pool must NOT be closed
+        assert pool_conn.pool is not None
+        # Rollback on exception, not commit
+        mock_inner_conn.rollback.assert_awaited_once()
+        mock_inner_conn.commit.assert_not_awaited()
+        # Connection still returned to pool
+        mock_pool_ctx.__aexit__.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_reusable(self):
+        """Pool should be reusable across multiple async with blocks."""
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.rollback = AsyncMock()
+
+        def make_ctx():
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(side_effect=[make_ctx(), make_ctx()])
+
+        # First use
+        async with pool_conn:
+            pass
+
+        # Second use - pool should still be alive
+        async with pool_conn:
+            pass
+
+        assert pool_conn.pool is not None
+        assert pool_conn.pool.connection.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cursor_uses_acquired_conn_inside_context(self):
+        """cursor() should use ContextVar conn when inside async with, not acquire new."""
+        mock_cursor = AsyncMock()
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.cursor = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_cursor),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        mock_pool_ctx = AsyncMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(return_value=mock_pool_ctx)
+
+        async with pool_conn:
+            async with pool_conn.cursor() as cur:
+                assert cur is mock_cursor
+
+        # pool.connection() called once (for __aenter__), not again for cursor()
+        pool_conn.pool.connection.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transaction_yields_self(self):
+        """transaction() should yield self for consistency with sync types."""
+        mock_inner_conn = MagicMock()
+        mock_inner_conn.commit = AsyncMock()
+        mock_inner_conn.transaction = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        mock_pool_ctx = AsyncMock()
+        mock_pool_ctx.__aenter__ = AsyncMock(return_value=mock_inner_conn)
+        mock_pool_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        pool_conn = PGAsyncPoolConnection({'host': 'localhost'})
+        pool_conn.pool = MagicMock()
+        pool_conn.pool.connection = MagicMock(return_value=mock_pool_ctx)
+
+        async with pool_conn:
+            async with pool_conn.transaction() as tx:
+                assert tx is pool_conn

--- a/src/pgmonkey/tests/unit/test_connection_factory.py
+++ b/src/pgmonkey/tests/unit/test_connection_factory.py
@@ -9,7 +9,7 @@ from pgmonkey.connections.postgres.async_pool_connection import PGAsyncPoolConne
 
 class TestPostgresConnectionFactory:
 
-    def test_filter_config_strips_empty_values(self, sample_config):
+    def test_filter_config_strips_empty_string_values(self, sample_config):
         """Empty string values like sslcert='' should be stripped from filtered config."""
         factory = PostgresConnectionFactory(sample_config, 'normal')
         assert 'sslcert' not in factory.config
@@ -35,9 +35,26 @@ class TestPostgresConnectionFactory:
         assert 'hosst' in caplog.text
         assert "Unknown connection settings ignored" in caplog.text
 
+    def test_filter_config_preserves_none_but_not_empty_string(self, sample_config):
+        """None values should be kept (is not None check), empty strings should be stripped."""
+        # None values are preserved by the `is not None` check
+        sample_config['postgresql']['connection_settings']['keepalives'] = None
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        assert 'keepalives' not in factory.config
+
+    def test_filter_config_preserves_zero_values(self, sample_config):
+        """Zero values like keepalives=0 should NOT be silently dropped."""
+        sample_config['postgresql']['connection_settings']['keepalives'] = 0
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        assert factory.config['keepalives'] == 0
+
     def test_extracts_pool_settings(self, sample_config):
         factory = PostgresConnectionFactory(sample_config, 'pool')
         assert factory.pool_settings == {'min_size': 2, 'max_size': 10, 'max_idle': 300, 'max_lifetime': 3600}
+
+    def test_extracts_sync_settings(self, sample_config):
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        assert factory.sync_settings['statement_timeout'] == '30000'
 
     def test_extracts_async_settings(self, sample_config):
         factory = PostgresConnectionFactory(sample_config, 'async')
@@ -52,17 +69,32 @@ class TestPostgresConnectionFactory:
         factory = PostgresConnectionFactory(sample_config, 'pool')
         assert factory.pool_settings == {}
 
+    def test_missing_sync_settings_defaults_to_empty(self, sample_config):
+        del sample_config['postgresql']['sync_settings']
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        assert factory.sync_settings == {}
+
     def test_get_connection_normal(self, sample_config):
         factory = PostgresConnectionFactory(sample_config, 'normal')
         conn = factory.get_connection()
         assert isinstance(conn, PGNormalConnection)
         assert conn.connection_type == 'normal'
 
+    def test_get_connection_normal_receives_sync_settings(self, sample_config):
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        conn = factory.get_connection()
+        assert conn.sync_settings == sample_config['postgresql']['sync_settings']
+
     def test_get_connection_pool(self, sample_config):
         factory = PostgresConnectionFactory(sample_config, 'pool')
         conn = factory.get_connection()
         assert isinstance(conn, PGPoolConnection)
         assert conn.connection_type == 'pool'
+
+    def test_get_connection_pool_receives_sync_settings(self, sample_config):
+        factory = PostgresConnectionFactory(sample_config, 'pool')
+        conn = factory.get_connection()
+        assert conn.sync_settings == sample_config['postgresql']['sync_settings']
 
     def test_get_connection_async(self, sample_config):
         factory = PostgresConnectionFactory(sample_config, 'async')
@@ -113,3 +145,29 @@ class TestPoolSettingsValidation:
         sample_config['postgresql']['pool_settings'] = {'min_size': 5, 'max_size': 5}
         factory = PostgresConnectionFactory(sample_config, 'pool')
         assert factory.pool_settings['min_size'] == factory.pool_settings['max_size']
+
+
+class TestAutocommitConfig:
+
+    def test_autocommit_true_set_on_connection(self, sample_config):
+        sample_config['postgresql']['connection_settings']['autocommit'] = True
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        conn = factory.get_connection()
+        assert conn.autocommit is True
+
+    def test_autocommit_false_set_on_connection(self, sample_config):
+        sample_config['postgresql']['connection_settings']['autocommit'] = False
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        conn = factory.get_connection()
+        assert conn.autocommit is False
+
+    def test_autocommit_not_set_leaves_default(self, sample_config):
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        conn = factory.get_connection()
+        assert conn.autocommit is None
+
+    def test_autocommit_removed_from_connection_config(self, sample_config):
+        """autocommit should not be passed as a psycopg connection parameter."""
+        sample_config['postgresql']['connection_settings']['autocommit'] = True
+        factory = PostgresConnectionFactory(sample_config, 'normal')
+        assert 'autocommit' not in factory.config

--- a/src/pgmonkey/tests/unit/test_normal_connection.py
+++ b/src/pgmonkey/tests/unit/test_normal_connection.py
@@ -11,6 +11,15 @@ class TestPGNormalConnectionInit:
         assert conn.config == {'host': 'localhost', 'dbname': 'test'}
         assert conn.connection is None
 
+    def test_stores_sync_settings(self):
+        settings = {'statement_timeout': '30000'}
+        conn = PGNormalConnection({'host': 'localhost'}, sync_settings=settings)
+        assert conn.sync_settings == settings
+
+    def test_default_sync_settings_empty(self):
+        conn = PGNormalConnection({'host': 'localhost'})
+        assert conn.sync_settings == {}
+
 
 class TestPGNormalConnectionConnect:
 
@@ -22,7 +31,7 @@ class TestPGNormalConnectionConnect:
         conn = PGNormalConnection({'host': 'localhost'})
         conn.connect()
 
-        mock_connect.assert_called_once_with(host='localhost')
+        mock_connect.assert_called_once_with(autocommit=False, host='localhost')
         assert conn.connection is mock_pg_conn
 
     @patch('pgmonkey.connections.postgres.normal_connection.connect')
@@ -34,6 +43,48 @@ class TestPGNormalConnectionConnect:
         conn.connect()
 
         mock_connect.assert_called_once()
+
+    @patch('pgmonkey.connections.postgres.normal_connection.connect')
+    def test_autocommit_passed_to_connect(self, mock_connect):
+        mock_pg_conn = MagicMock(closed=False)
+        mock_connect.return_value = mock_pg_conn
+
+        conn = PGNormalConnection({'host': 'localhost'})
+        conn.autocommit = True
+        conn.connect()
+
+        mock_connect.assert_called_once_with(autocommit=True, host='localhost')
+
+
+class TestPGNormalConnectionSyncSettings:
+
+    @patch('pgmonkey.connections.postgres.normal_connection.connect')
+    def test_applies_sync_settings_on_connect(self, mock_connect):
+        mock_pg_conn = MagicMock(closed=False)
+        mock_connect.return_value = mock_pg_conn
+
+        settings = {'statement_timeout': '30000', 'lock_timeout': '10000'}
+        conn = PGNormalConnection({'host': 'localhost'}, sync_settings=settings)
+        conn.connect()
+
+        calls = mock_pg_conn.execute.call_args_list
+        assert len(calls) == 2
+        assert calls[0][0][0] == 'SET statement_timeout = %s'
+        assert calls[0][0][1] == ('30000',)
+        assert calls[1][0][0] == 'SET lock_timeout = %s'
+        assert calls[1][0][1] == ('10000',)
+
+    @patch('pgmonkey.connections.postgres.normal_connection.connect')
+    def test_warns_on_bad_setting(self, mock_connect, caplog):
+        mock_pg_conn = MagicMock(closed=False)
+        mock_pg_conn.execute.side_effect = Exception("bad setting")
+        mock_connect.return_value = mock_pg_conn
+
+        conn = PGNormalConnection({'host': 'localhost'}, sync_settings={'bad': 'value'})
+        with caplog.at_level(logging.WARNING):
+            conn.connect()
+
+        assert "Could not apply setting" in caplog.text
 
 
 class TestPGNormalConnectionDisconnect:
@@ -105,7 +156,8 @@ class TestPGNormalConnectionCursor:
 class TestPGNormalConnectionContextManager:
 
     @patch('pgmonkey.connections.postgres.normal_connection.connect')
-    def test_commits_on_success(self, mock_connect):
+    def test_commits_on_success_without_disconnect(self, mock_connect):
+        """__exit__ commits but does not disconnect — connection stays alive for cache reuse."""
         mock_pg_conn = MagicMock(closed=False)
         mock_connect.return_value = mock_pg_conn
 
@@ -114,7 +166,7 @@ class TestPGNormalConnectionContextManager:
             assert c is conn
 
         mock_pg_conn.commit.assert_called_once()
-        mock_pg_conn.close.assert_called_once()
+        mock_pg_conn.close.assert_not_called()
 
     @patch('pgmonkey.connections.postgres.normal_connection.connect')
     def test_rollbacks_on_error(self, mock_connect):
@@ -161,6 +213,16 @@ class TestPGNormalConnectionTransaction:
         mock_pg_conn.rollback.assert_called_once()
         mock_pg_conn.commit.assert_not_called()
         mock_pg_conn.close.assert_not_called()
+
+    @patch('pgmonkey.connections.postgres.normal_connection.connect')
+    def test_transaction_yields_self(self, mock_connect):
+        mock_pg_conn = MagicMock(closed=False)
+        mock_connect.return_value = mock_pg_conn
+
+        conn = PGNormalConnection({'host': 'localhost'})
+        conn.connect()
+        with conn.transaction() as tx:
+            assert tx is conn
 
 
 class TestPGNormalConnectionTestConnection:


### PR DESCRIPTION
…n, and more

1. CRITICAL: Thread/task safety for cached pool connections
   - PGPoolConnection: use threading.local() for borrowed connection storage
   - PGAsyncPoolConnection: use contextvars.ContextVar for borrowed connection storage
   - Prevents data corruption when multiple threads/tasks share a cached pool

2. HIGH: Add sync_settings (GUC) support for normal and pool connections
   - Normal connections: apply via SET commands after connect
   - Pool connections: apply via psycopg_pool configure callback on checkout
   - Mirrors existing async_settings pattern for consistency

3. HIGH: Expose additional pool parameters in YAML template
   - max_waiting, reconnect_timeout, num_workers now documented and passable
   - These are passed through to psycopg_pool via kwargs dict

4. MEDIUM: Fix SQL injection in CSV import/export tools
   - Replace f-string SQL interpolation with psycopg.sql.Identifier/SQL/Literal
   - Use parameterized queries for information_schema lookups and SET commands

5. MEDIUM: Stop NormalConnection.__exit__ from disconnecting cached connections
   - __exit__ now commits/rollbacks without calling disconnect()
   - Same fix applied to AsyncConnection.__aexit__
   - Connections stay alive for cache reuse; atexit handler handles cleanup

6. MEDIUM: Add autocommit mode configuration
   - New autocommit key in connection_settings (YAML config)
   - Passed to psycopg connect() for normal and async connections
   - Required for DDL operations like CREATE DATABASE, VACUUM, etc.

7. MEDIUM: Fix transaction() yield inconsistency across all 4 connection types
   - All types now consistently yield self (the pgmonkey wrapper)
   - Previously: async yielded nothing, async_pool yielded raw psycopg tx object

8. LOW: Fix falsy config values being silently dropped
   - Changed filter from `and config[key]` to `and config[key] is not None and config[key] != ''`
   - Zero values like keepalives=0 are now preserved; empty strings still stripped

All 182 unit tests pass.

https://claude.ai/code/session_01K6h79Zxr4e1nQbwXmTXnjn