### PR TITLE
Bump to v3.1.0 with quality, safety, and library hygiene fixes

### DIFF
--- a/PROJECTSCOPE.md
+++ b/PROJECTSCOPE.md
@@ -209,7 +209,7 @@ parsing and print output. Business logic lives in `managers/` and `tools/`.
 
 ## Version & Compatibility
 
-- **Current version:** 2.2.0
+- **Current version:** 3.1.0
 - **Python:** 3.10+
 - **psycopg:** >=3.1.20, <4.0.0
 - **psycopg_pool:** >=3.1.9, <4.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pgmonkey"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
   { name="Good Boy", email="pythonic@rexbytes.com" },
 ]

--- a/src/pgmonkey/cli/cli_export_subparser.py
+++ b/src/pgmonkey/cli/cli_export_subparser.py
@@ -1,4 +1,5 @@
 from pgmonkey.managers.pgexport_manager import PGExportManager
+from pgmonkey.common.exceptions import ConfigFileCreatedError
 from pathlib import Path
 
 
@@ -41,5 +42,8 @@ def pgexport_handler(args):
 
     # Proceed with exporting the table data to CSV (the export settings file is automatically derived)
     # print(f"Starting export of table: {table_name} to CSV file: {export_file if export_file else 'default based on table name'}")
-    pgexport_manager.export_table(table_name, connection_config, export_file)
-    print("Export complete.")
+    try:
+        pgexport_manager.export_table(table_name, connection_config, export_file)
+        print("Export complete.")
+    except ConfigFileCreatedError as e:
+        print(e)

--- a/src/pgmonkey/cli/cli_import_subparser.py
+++ b/src/pgmonkey/cli/cli_import_subparser.py
@@ -1,4 +1,5 @@
 from pgmonkey.managers.pgimport_manager import PGImportManager
+from pgmonkey.common.exceptions import ConfigFileCreatedError
 from pathlib import Path
 
 def cli_pgimport_subparser(subparsers):
@@ -39,6 +40,9 @@ def pgimport_handler(args):
 
     # Proceed with importing the file (the settings file is automatically derived)
     # print(f"Starting import for file: {import_file} into table: {table_name}")
-    pgimport_manager.import_file(import_file, table_name, connection_config)
-    print("Import complete.")
+    try:
+        pgimport_manager.import_file(import_file, table_name, connection_config)
+        print("Import complete.")
+    except ConfigFileCreatedError as e:
+        print(e)
 

--- a/src/pgmonkey/common/exceptions.py
+++ b/src/pgmonkey/common/exceptions.py
@@ -1,0 +1,3 @@
+class ConfigFileCreatedError(Exception):
+    """Raised when a config file has been auto-generated and needs user review before proceeding."""
+    pass

--- a/src/pgmonkey/connections/postgres/normal_connection.py
+++ b/src/pgmonkey/connections/postgres/normal_connection.py
@@ -51,7 +51,9 @@ class PGNormalConnection(PostgresBaseConnection):
             self.connection.rollback()
 
     def cursor(self):
-        return self.connection.cursor()
+        if self.connection:
+            return self.connection.cursor()
+        raise Exception("No active connection available to create a cursor")
 
     @contextmanager
     def transaction(self):

--- a/src/pgmonkey/serversettings/postgres_server_config_generator.py
+++ b/src/pgmonkey/serversettings/postgres_server_config_generator.py
@@ -44,10 +44,10 @@ class PostgresServerConfigGenerator:
 
         if sslmode in ['verify-ca', 'verify-full']:
             clientcert = 'verify-full' if sslmode == 'verify-full' else 'verify-ca'
-            entry = f"hostssl all     all   {address}    md5     clientcert={clientcert}"
+            entry = f"hostssl all     all   {address}    scram-sha-256     clientcert={clientcert}"
             entries.append(entry)
         elif sslmode != 'disable':
-            entry = f"hostssl all     all   {address}    md5"
+            entry = f"hostssl all     all   {address}    scram-sha-256"
             entries.append(entry)
         return entries
 

--- a/src/pgmonkey/tests/unit/test_csv_data_exporter.py
+++ b/src/pgmonkey/tests/unit/test_csv_data_exporter.py
@@ -1,0 +1,132 @@
+import pytest
+import yaml
+from unittest.mock import patch, MagicMock
+from pgmonkey.tools.csv_data_exporter import CSVDataExporter
+from pgmonkey.common.exceptions import ConfigFileCreatedError
+
+
+class TestCSVDataExporterInit:
+
+    def test_schema_table_split(self, tmp_path):
+        """table_name with a dot should split into schema and table."""
+        config_file = tmp_path / "conn.yaml"
+        config_file.write_text(yaml.dump({
+            'connection_type': 'normal',
+            'connection_settings': {'host': 'localhost', 'dbname': 'test'},
+        }))
+        export_config = tmp_path / "export.yaml"
+        export_config.write_text(yaml.dump({
+            'delimiter': ',', 'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        exporter = CSVDataExporter(
+            str(config_file), "myschema.mytable",
+            csv_file=str(tmp_path / "out.csv"),
+            export_config_file=str(export_config),
+        )
+        assert exporter.schema_name == "myschema"
+        assert exporter.table_name == "mytable"
+
+    def test_default_schema_is_public(self, tmp_path):
+        """table_name without a dot should default schema to 'public'."""
+        config_file = tmp_path / "conn.yaml"
+        config_file.write_text(yaml.dump({
+            'connection_type': 'normal',
+            'connection_settings': {'host': 'localhost', 'dbname': 'test'},
+        }))
+        export_config = tmp_path / "export.yaml"
+        export_config.write_text(yaml.dump({
+            'delimiter': ',', 'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        exporter = CSVDataExporter(
+            str(config_file), "mytable",
+            csv_file=str(tmp_path / "out.csv"),
+            export_config_file=str(export_config),
+        )
+        assert exporter.schema_name == "public"
+        assert exporter.table_name == "mytable"
+
+    def test_multi_dot_table_name(self, tmp_path):
+        """table_name with multiple dots should only split on the first dot."""
+        config_file = tmp_path / "conn.yaml"
+        config_file.write_text(yaml.dump({
+            'connection_type': 'normal',
+            'connection_settings': {'host': 'localhost', 'dbname': 'test'},
+        }))
+        export_config = tmp_path / "export.yaml"
+        export_config.write_text(yaml.dump({
+            'delimiter': ',', 'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        exporter = CSVDataExporter(
+            str(config_file), "catalog.schema.table",
+            csv_file=str(tmp_path / "out.csv"),
+            export_config_file=str(export_config),
+        )
+        assert exporter.schema_name == "catalog"
+        assert exporter.table_name == "schema.table"
+
+    def test_tab_delimiter_unescaped(self, tmp_path):
+        """Tab delimiter specified as literal backslash-t should be converted to real tab."""
+        config_file = tmp_path / "conn.yaml"
+        config_file.write_text(yaml.dump({
+            'connection_type': 'normal',
+            'connection_settings': {'host': 'localhost', 'dbname': 'test'},
+        }))
+        export_config = tmp_path / "export.yaml"
+        export_config.write_text(yaml.dump({
+            'delimiter': r'\t', 'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        exporter = CSVDataExporter(
+            str(config_file), "mytable",
+            csv_file=str(tmp_path / "out.csv"),
+            export_config_file=str(export_config),
+        )
+        assert exporter.delimiter == '\t'
+
+
+class TestExportConfigCreation:
+
+    @patch('pgmonkey.tools.csv_data_exporter.PGConnectionManager')
+    def test_config_file_created_when_missing(self, mock_mgr_cls, tmp_path):
+        """When no export config exists, it should be auto-created and raise ConfigFileCreatedError."""
+        config_file = tmp_path / "conn.yaml"
+        config_file.write_text(yaml.dump({
+            'connection_type': 'normal',
+            'connection_settings': {'host': 'localhost', 'dbname': 'test'},
+        }))
+
+        # Mock the connection manager to return a mock connection
+        mock_mgr = MagicMock()
+        mock_mgr_cls.return_value = mock_mgr
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = ('UTF8',)
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_mgr.get_database_connection.return_value = mock_conn
+
+        csv_file = str(tmp_path / "out.csv")
+        with pytest.raises(ConfigFileCreatedError):
+            CSVDataExporter(str(config_file), "mytable", csv_file=csv_file)
+
+        # The export config file should have been created
+        export_config = tmp_path / "out.yaml"
+        assert export_config.exists()
+
+
+class TestResolveConnectionType:
+
+    def test_normal_type_stays_normal(self):
+        assert CSVDataExporter._resolve_export_connection_type({'connection_type': 'normal'}) == 'normal'
+
+    def test_async_type_becomes_normal(self):
+        assert CSVDataExporter._resolve_export_connection_type({'connection_type': 'async'}) == 'normal'
+
+    def test_async_pool_type_becomes_normal(self):
+        assert CSVDataExporter._resolve_export_connection_type({'connection_type': 'async_pool'}) == 'normal'

--- a/src/pgmonkey/tests/unit/test_csv_data_importer.py
+++ b/src/pgmonkey/tests/unit/test_csv_data_importer.py
@@ -1,0 +1,193 @@
+import csv
+import os
+import pytest
+import yaml
+from unittest.mock import patch, MagicMock
+from pgmonkey.tools.csv_data_importer import CSVDataImporter
+from pgmonkey.common.exceptions import ConfigFileCreatedError
+
+
+class TestCSVDataImporterInit:
+
+    def test_schema_table_split(self, tmp_path):
+        """table_name with a dot should split into schema and table."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("col1,col2\na,b\n")
+        config_file = tmp_path / "data.yaml"
+        config_file.write_text(yaml.dump({
+            'has_headers': True, 'auto_create_table': True,
+            'enforce_lowercase': True, 'delimiter': ',',
+            'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        importer = CSVDataImporter(
+            str(tmp_path / "conn.yaml"), str(csv_file),
+            "myschema.mytable", str(config_file),
+        )
+        assert importer.schema_name == "myschema"
+        assert importer.table_name == "mytable"
+
+    def test_default_schema_is_public(self, tmp_path):
+        """table_name without a dot should default schema to 'public'."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("col1,col2\na,b\n")
+        config_file = tmp_path / "data.yaml"
+        config_file.write_text(yaml.dump({
+            'has_headers': True, 'auto_create_table': True,
+            'enforce_lowercase': True, 'delimiter': ',',
+            'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        importer = CSVDataImporter(
+            str(tmp_path / "conn.yaml"), str(csv_file),
+            "mytable", str(config_file),
+        )
+        assert importer.schema_name == "public"
+        assert importer.table_name == "mytable"
+
+    def test_multi_dot_table_name(self, tmp_path):
+        """table_name with multiple dots should only split on the first dot."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("col1\na\n")
+        config_file = tmp_path / "data.yaml"
+        config_file.write_text(yaml.dump({
+            'has_headers': True, 'auto_create_table': True,
+            'enforce_lowercase': True, 'delimiter': ',',
+            'quotechar': '"', 'encoding': 'utf-8',
+        }))
+
+        importer = CSVDataImporter(
+            str(tmp_path / "conn.yaml"), str(csv_file),
+            "catalog.schema.table", str(config_file),
+        )
+        assert importer.schema_name == "catalog"
+        assert importer.table_name == "schema.table"
+
+    def test_config_file_created_when_missing(self, tmp_path):
+        """When no import config exists, it should be auto-created and raise ConfigFileCreatedError."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("col1,col2\na,b\n")
+
+        with pytest.raises(ConfigFileCreatedError):
+            CSVDataImporter(
+                str(tmp_path / "conn.yaml"), str(csv_file),
+                "mytable",
+            )
+
+        # The config file should have been created
+        auto_config = tmp_path / "data.yaml"
+        assert auto_config.exists()
+
+
+class TestBOMDetection:
+
+    def _make_importer(self, tmp_path):
+        """Helper to create an importer with a pre-existing config."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("col1\na\n")
+        config_file = tmp_path / "data.yaml"
+        config_file.write_text(yaml.dump({
+            'has_headers': True, 'auto_create_table': True,
+            'enforce_lowercase': True, 'delimiter': ',',
+            'quotechar': '"', 'encoding': 'utf-8',
+        }))
+        return CSVDataImporter(
+            str(tmp_path / "conn.yaml"), str(csv_file),
+            "mytable", str(config_file),
+        )
+
+    def test_utf8_bom(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\xef\xbb\xbfcol1\n')
+        assert importer._detect_bom() == 'utf-8-sig'
+
+    def test_utf16_le_bom(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\xff\xfec\x00o\x00l\x001\x00\n\x00')
+        assert importer._detect_bom() == 'utf-16-le'
+
+    def test_utf16_be_bom(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\xfe\xff\x00c\x00o\x00l\x001\x00\n')
+        assert importer._detect_bom() == 'utf-16-be'
+
+    def test_utf32_le_bom(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\xff\xfe\x00\x00c\x00\x00\x00')
+        assert importer._detect_bom() == 'utf-32-le'
+
+    def test_utf32_be_bom(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\x00\x00\xfe\xffc\x00\x00\x00')
+        assert importer._detect_bom() == 'utf-32-be'
+
+    def test_utf32_le_not_misdetected_as_utf16_le(self, tmp_path):
+        """UTF-32-LE BOM starts with same bytes as UTF-16-LE. Must detect UTF-32 first."""
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'\xff\xfe\x00\x00data')
+        assert importer._detect_bom() == 'utf-32-le'
+
+    def test_no_bom_returns_none(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_bytes(b'col1,col2\na,b\n')
+        assert importer._detect_bom() is None
+
+
+class TestColumnNameFormatting:
+
+    def _make_importer(self, tmp_path, csv_content="col1\na\n"):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text(csv_content)
+        config_file = tmp_path / "data.yaml"
+        config_file.write_text(yaml.dump({
+            'has_headers': True, 'auto_create_table': True,
+            'enforce_lowercase': True, 'delimiter': ',',
+            'quotechar': '"', 'encoding': 'utf-8',
+        }))
+        return CSVDataImporter(
+            str(tmp_path / "conn.yaml"), str(csv_file),
+            "mytable", str(config_file),
+        )
+
+    def test_spaces_replaced_with_underscores(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        result = importer._format_column_names(["First Name", "Last Name"])
+        assert result == ["first_name", "last_name"]
+
+    def test_special_chars_replaced(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        result = importer._format_column_names(["email@address", "phone#"])
+        assert result == ["email_address", "phone_"]
+
+    def test_empty_columns_skipped(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        result = importer._format_column_names(["name", "", "age"])
+        assert result == ["name", "age"]
+
+    def test_valid_column_name(self, tmp_path):
+        importer = self._make_importer(tmp_path)
+        assert importer._is_valid_column_name("valid_name")
+        assert importer._is_valid_column_name("_private")
+        assert not importer._is_valid_column_name("123invalid")
+
+
+class TestResolveConnectionType:
+
+    def test_normal_type_stays_normal(self):
+        assert CSVDataImporter._resolve_import_connection_type({'connection_type': 'normal'}) == 'normal'
+
+    def test_pool_type_becomes_normal(self):
+        assert CSVDataImporter._resolve_import_connection_type({'connection_type': 'pool'}) == 'normal'
+
+    def test_async_type_becomes_normal(self):
+        assert CSVDataImporter._resolve_import_connection_type({'connection_type': 'async'}) == 'normal'
+
+    def test_async_pool_type_becomes_normal(self):
+        assert CSVDataImporter._resolve_import_connection_type({'connection_type': 'async_pool'}) == 'normal'

--- a/src/pgmonkey/tests/unit/test_normal_connection.py
+++ b/src/pgmonkey/tests/unit/test_normal_connection.py
@@ -153,6 +153,12 @@ class TestPGNormalConnectionCursor:
         conn.connect()
         assert conn.cursor() is mock_cursor
 
+    def test_raises_when_no_connection(self):
+        """cursor() should raise a clear error when connection is None."""
+        conn = PGNormalConnection({'host': 'localhost'})
+        with pytest.raises(Exception, match="No active connection"):
+            conn.cursor()
+
 
 class TestPGNormalConnectionContextManager:
 

--- a/src/pgmonkey/tests/unit/test_server_config_generator.py
+++ b/src/pgmonkey/tests/unit/test_server_config_generator.py
@@ -64,7 +64,7 @@ class TestPgHbaEntry:
 
         assert len(entries) == 2
         assert 'hostssl' in entries[1]
-        assert 'md5' in entries[1]
+        assert 'scram-sha-256' in entries[1]
         assert '192.168.1.0/24' in entries[1]
         # Should NOT have clientcert option (that's only for verify-ca/verify-full)
         assert 'clientcert' not in entries[1]
@@ -77,7 +77,7 @@ class TestPgHbaEntry:
 
         assert len(entries) == 2
         assert 'hostssl' in entries[1]
-        assert 'md5' in entries[1]
+        assert 'scram-sha-256' in entries[1]
         assert 'clientcert' not in entries[1]
 
     def test_disable_generates_no_entry(self, sample_config, tmp_path):

--- a/src/pgmonkey/tools/csv_data_exporter.py
+++ b/src/pgmonkey/tools/csv_data_exporter.py
@@ -1,12 +1,12 @@
 import csv
 import os
 import yaml
-import sys
 from psycopg import sql
 from pathlib import Path
 from tqdm import tqdm
 from pgmonkey import PGConnectionManager
 from pgmonkey.common.utils.configutils import normalize_config
+from pgmonkey.common.exceptions import ConfigFileCreatedError
 
 
 class CSVDataExporter:
@@ -16,7 +16,7 @@ class CSVDataExporter:
 
         # Handle schema and table name
         if '.' in table_name:
-            self.schema_name, self.table_name = table_name.split('.')
+            self.schema_name, self.table_name = table_name.split('.', 1)
         else:
             self.schema_name = 'public'
             self.table_name = table_name
@@ -137,8 +137,10 @@ class CSVDataExporter:
         print(f"Export configuration file '{self.export_config_file}' has been created.")
         print("Please review the file and adjust settings if necessary before running the export process again.")
 
-        # Exit the process to allow the user to review the file
-        sys.exit(0)
+        raise ConfigFileCreatedError(
+            f"Export configuration file '{self.export_config_file}' has been created. "
+            "Please review the file and adjust settings if necessary before running the export process again."
+        )
 
     def _sync_export(self, connection):
         """Handles synchronous export of the table data to CSV using COPY TO with a progress bar."""

--- a/src/pgmonkey/tools/csv_data_importer.py
+++ b/src/pgmonkey/tools/csv_data_importer.py
@@ -9,6 +9,7 @@ from pgmonkey import PGConnectionManager
 from pathlib import Path
 from tqdm import tqdm
 from pgmonkey.common.utils.configutils import normalize_config
+from pgmonkey.common.exceptions import ConfigFileCreatedError
 
 
 class CSVDataImporter:
@@ -19,7 +20,7 @@ class CSVDataImporter:
 
         # Handle schema and table name
         if '.' in table_name:
-            self.schema_name, self.table_name = table_name.split('.')
+            self.schema_name, self.table_name = table_name.split('.', 1)
         else:
             self.schema_name = 'public'
             self.table_name = table_name
@@ -177,8 +178,10 @@ class CSVDataImporter:
         print(f"Import configuration file '{self.import_config_file}' has been created.")
         print("Please review the file and adjust settings if necessary before running the import process again.")
 
-        # Exit the process to allow the user to review the file
-        sys.exit(0)
+        raise ConfigFileCreatedError(
+            f"Import configuration file '{self.import_config_file}' has been created. "
+            "Please review the file and adjust settings if necessary before running the import process again."
+        )
 
     def _format_column_names(self, headers):
         """Formats column names by lowercasing and replacing spaces with underscores."""
@@ -229,8 +232,6 @@ class CSVDataImporter:
     def _sync_ingest(self, connection):
         """Handles synchronous CSV ingestion using COPY for bulk insert, properly counting non-empty rows."""
         # Increase the CSV field size limit
-        import csv
-        import sys
         max_int = sys.maxsize
         while True:
             try:


### PR DESCRIPTION
- Add None guard to normal_connection.cursor() matching other connection types
- Change pg_hba auth recommendations from deprecated md5 to scram-sha-256
- Replace sys.exit(0) in CSV tools with ConfigFileCreatedError exception
- Fix table_name.split('.') crash on multi-dot names (use split('.', 1))
- Remove shadowed imports in csv_data_importer._sync_ingest
- Update stale version in PROJECTSCOPE.md (2.2.0 -> 3.1.0)
- Add 28 new unit tests for CSV import/export (257 total, all passing)

https://claude.ai/code/session_01ShQ67M5QvEfA5wT3FWXg61