### PR TITLE
Add SEO files and meta tags to all documentation pages

### DIFF
--- a/docs/best_practices.html
+++ b/docs/best_practices.html
@@ -171,6 +171,18 @@ footer .legal { font-size: 0.8em; color: #64748b; max-width: 700px; margin: 12px
     .recipe { padding: 20px; }
 }
     </style>
+    <meta name="description" content="pgmonkey best practice recipes - production-ready code patterns for sync, async, pooled, and async-pooled PostgreSQL connections in Python.">
+    <meta name="keywords" content="pgmonkey, PostgreSQL, Python, best practices, connection pool, async pool, Flask, FastAPI, psycopg, design patterns, production, recipes">
+    <meta name="author" content="RexBytes">
+    <link rel="canonical" href="https://pgmonkey.net/best_practices.html">
+    <meta property="og:title" content="pgmonkey - Best Practice Recipes">
+    <meta property="og:description" content="Production-ready code patterns for sync, async, pooled, and async-pooled PostgreSQL connections in Python.">
+    <meta property="og:url" content="https://pgmonkey.net/best_practices.html">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="pgmonkey">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="pgmonkey - Best Practice Recipes">
+    <meta name="twitter:description" content="Production-ready code patterns for sync, async, pooled, and async-pooled PostgreSQL connections in Python.">
 </head>
 <body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -233,12 +233,41 @@ footer .legal { font-size: 0.8em; color: #64748b; max-width: 700px; margin: 12px
 }
     </style>
     <meta name="description" content="pgmonkey - One config file, every PostgreSQL connection type. Sync, async, pooled, and async-pooled connections in Python.">
-    <meta name="keywords" content="PostgreSQL, Python, database, connection management, pgmonkey, psycopg, connection pool, async">
+    <meta name="keywords" content="PostgreSQL, Python, database, connection management, pgmonkey, psycopg, connection pool, async, psycopg3, asyncio, database pooling, YAML config">
     <meta name="author" content="RexBytes">
+    <link rel="canonical" href="https://pgmonkey.net/">
     <meta property="og:title" content="pgmonkey - Simplify PostgreSQL Connections">
     <meta property="og:description" content="One config file, every PostgreSQL connection type. Sync, async, pooled, and async-pooled connections in Python.">
-    <meta property="og:url" content="https://pgmonkey.net">
+    <meta property="og:url" content="https://pgmonkey.net/">
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="pgmonkey">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="pgmonkey - Simplify PostgreSQL Connections">
+    <meta name="twitter:description" content="One config file, every PostgreSQL connection type. Sync, async, pooled, and async-pooled connections in Python.">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "pgmonkey",
+      "description": "PostgreSQL connection management library for Python. One config file, every connection type - sync, async, pooled, and async-pooled.",
+      "url": "https://pgmonkey.net/",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux, macOS, Windows",
+      "programmingLanguage": "Python",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "license": "https://github.com/RexBytes/pgmonkey/blob/main/LICENSE",
+      "codeRepository": "https://github.com/RexBytes/pgmonkey",
+      "author": {
+        "@type": "Organization",
+        "name": "RexBytes",
+        "url": "https://github.com/RexBytes"
+      }
+    }
+    </script>
 </head>
 <body>
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -176,6 +176,18 @@ footer p { margin-bottom: 8px; }
     pre { padding: 14px 16px; font-size: 0.85em; }
 }
     </style>
+    <meta name="description" content="pgmonkey reference guide - CLI commands, YAML configuration options, Python API, connection pooling, async support, and code examples for PostgreSQL.">
+    <meta name="keywords" content="pgmonkey, PostgreSQL, Python, reference, CLI, YAML config, connection pool, async, psycopg, API, code generation, CSV import, CSV export">
+    <meta name="author" content="RexBytes">
+    <link rel="canonical" href="https://pgmonkey.net/reference.html">
+    <meta property="og:title" content="pgmonkey - Reference Guide">
+    <meta property="og:description" content="CLI commands, YAML configuration options, Python API, connection pooling, async support, and code examples for PostgreSQL.">
+    <meta property="og:url" content="https://pgmonkey.net/reference.html">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="pgmonkey">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="pgmonkey - Reference Guide">
+    <meta name="twitter:description" content="CLI commands, YAML configuration options, Python API, connection pooling, async support, and code examples for PostgreSQL.">
 </head>
 <body>
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pgmonkey.net/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://pgmonkey.net/</loc>
+    <lastmod>2026-02-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://pgmonkey.net/reference.html</loc>
+    <lastmod>2026-02-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://pgmonkey.net/best_practices.html</loc>
+    <lastmod>2026-02-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
- robots.txt: allows all crawlers, points to sitemap
- sitemap.xml: lists all 3 pages with priorities (index 1.0, reference 0.8, best practices 0.7)
- Canonical URLs on all pages to prevent duplicate content issues
- Open Graph tags on reference.html and best_practices.html (index.html already had partial)
- Twitter Card tags on all 3 pages for social media previews
- JSON-LD SoftwareApplication structured data on index.html for rich search snippets
- Keywords and description meta tags on reference.html and best_practices.html
- Expanded keywords on index.html with additional relevant terms
- og:site_name added to all pages

https://claude.ai/code/session_01V5MPMjpmqKCuJvH5XYrdkL